### PR TITLE
Remove branch parameter from test badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# utils [![Test](https://github.com/inovacc/utils/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/inovacc/utils/actions/workflows/test.yml)
+# utils [![Test](https://github.com/inovacc/utils/actions/workflows/test.yml/badge.svg)](https://github.com/inovacc/utils/actions/workflows/test.yml)
 
 Collection of utility functions and packages for various cryptographic and encoding operations. The project is organized
 into several packages, each serving a specific purpose.


### PR DESCRIPTION
Updated the test badge URL to remove the specific branch parameter. This ensures the badge always reflects the latest workflow status across all branches.